### PR TITLE
fix usage of encoding when hashing strings:

### DIFF
--- a/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmCarroll2003.java
+++ b/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmCarroll2003.java
@@ -1,6 +1,7 @@
 package de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.util.Collections;
@@ -391,7 +392,7 @@ public class SignatureAlgorithmCarroll2003 implements SignatureAlgorithmInterfac
 		d.reset();
 		for (Triple t:triples){
 			if (Ontology.isRelevantForHash(t)){
-				byte[] tripleBytes=(t.getSubject()+t.getPredicate()+t.getObject()).getBytes();
+				byte[] tripleBytes=(t.getSubject()+t.getPredicate()+t.getObject()).getBytes(StandardCharsets.UTF_8);
 				d.update(tripleBytes);
 			}
 		}

--- a/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmFisteus2010.java
+++ b/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmFisteus2010.java
@@ -115,7 +115,7 @@ public class SignatureAlgorithmFisteus2010 implements SignatureAlgorithmInterfac
 				hashGraphCountCollisions(g);
 			}
 			
-			System.out.println("******* ITERATIONS: " + i);
+			//System.out.println("******* ITERATIONS: " + i);
 			
 			//End if there are no collisions
 			if (collisions==0){

--- a/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmFisteus2010.java
+++ b/src/de/uni_koblenz/aggrimm/icp/crypto/sign/algorithm/algorithm/SignatureAlgorithmFisteus2010.java
@@ -1,6 +1,7 @@
 package de.uni_koblenz.aggrimm.icp.crypto.sign.algorithm.algorithm;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.util.ArrayList;
@@ -448,7 +449,7 @@ public class SignatureAlgorithmFisteus2010 implements SignatureAlgorithmInterfac
 	 * @return  hash value as BigInteger
 	 */
 	private BigInteger hashString(String s){
-		return new BigInteger( digestGen.digest(s.getBytes()) );
+		return new BigInteger( digestGen.digest(s.getBytes(StandardCharsets.UTF_8)) );
 	}
 	
 	/**


### PR DESCRIPTION
prevent verification from failing if signed on one machine and verified by the another one with another default encoding
